### PR TITLE
Patch to support Python versions 2 and 3 on the same code:

### DIFF
--- a/mailbot/mailbot.py
+++ b/mailbot/mailbot.py
@@ -59,7 +59,14 @@ class MailBot(object):
 
         for uid, msg in messages.items():
             self.mark_processing(uid)
-            message = message_from_string(msg['RFC822'])
+
+            # Patch required for Python 3 compatibility:
+            # In Python 3.x, IMAPClient returns byte arrays instead of str
+            if 'RFC822' in msg:
+                message = message_from_string(msg['RFC822'])
+            elif b'RFC822' in msg:
+                message = message_from_string(msg[b'RFC822'].decode('utf-8'))
+
             for callback_class, rules in CALLBACKS_MAP.items():
                 self.process_message(message, callback_class, rules)
             self.mark_processed(uid)


### PR DESCRIPTION
According to its documentation, IMAPClient returns messages as strings in Python 2, but returns them as byte arrays in Python 3, which is quite inconsistent, and breaks mailbot's under Python 3 (code is designed to work with strings only).
